### PR TITLE
Better examples for globalprops-parseint.js

### DIFF
--- a/live-examples/js-examples/globalprops/globalprops-parseint.js
+++ b/live-examples/js-examples/globalprops/globalprops-parseint.js
@@ -1,11 +1,16 @@
-function roughScale(x, base) {
-  const parsed = parseInt(x, base);
-  if (isNaN(parsed)) { return 0; }
-  return parsed * 100;
-}
-
-console.log(roughScale(' 0xF', 16));
-// Expected output: 1500
-
-console.log(roughScale('321', 2));
-// Expected output: 0
+console.log(parseInt('123'));
+// 123 (default base-10)
+console.log(parseInt('123', 10));
+// 123 (explicitly specify base-10)
+console.log(parseInt('   123 '));
+// 123 (whitespace is ignored)
+console.log(parseInt('077'));
+// 77 (leading zeros are ignored)
+console.log(parseInt('1.9'));
+// 1 (decimal part is truncated)
+console.log(parseInt('ff', 16));
+// 255 (lower-case hexadecimal)
+console.log(parseInt('0xFF', 16));
+// 255 (upper-case hexadecimal with "0x" prefix)
+console.log(parseInt('xyz'));
+// NaN (input can't be converted to an integer)


### PR DESCRIPTION
### Description

This change swaps out the current example with simply calling the `parseInt` function directly and showing the results given various inputs.

### Motivation

The current example, `roughScale`, doesn't seem to have any real-world use case and just adds unnecessary confusion.

### Additional details

N/A

### Related issues and pull requests

N/A